### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/crate-paths-cli-core/CHANGELOG.md
+++ b/crates/crate-paths-cli-core/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-cli-core-v0.1.0) - 2025-06-15
+
+### Fixed
+
+- fix publishing order conflict?
+- fix #2
+
+### Other
+
+- .
+- apply changes made from #3
+- Update item.rs
+- Update mod.rs
+- make clippy happy
+- Update lib.rs
+- fmt
+- rework clippy + fmt
+- .

--- a/crates/crate-paths-cli/CHANGELOG.md
+++ b/crates/crate-paths-cli/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-cli-v0.1.0) - 2025-06-15
+
+### Fixed
+
+- fix publishing order conflict?
+
+### Other
+
+- .
+- remove folder option from transitive
+- .
+- also export cli as a lib. ???
+- fmt
+- rework clippy + fmt
+- .

--- a/crates/crate-paths-macros/CHANGELOG.md
+++ b/crates/crate-paths-macros/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-macros-v0.1.0) - 2025-06-15
+
+### Fixed
+
+- fix publishing order conflict?
+
+### Other
+
+- .
+- .

--- a/crates/crate-paths/CHANGELOG.md
+++ b/crates/crate-paths/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-v0.1.0) - 2025-06-15
+
+### Fixed
+
+- fix publishing order conflict?
+
+### Other
+
+- .
+- use correct `macros` feature
+- .
+- fmt
+- rework clippy + fmt
+- .


### PR DESCRIPTION



## 🤖 New release

* `crate-paths-macros`: 0.1.0
* `crate-paths`: 0.1.0
* `crate-paths-cli-core`: 0.1.0
* `crate-paths-cli`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `crate-paths-macros`

<blockquote>

## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-macros-v0.1.0) - 2025-06-15

### Fixed

- fix publishing order conflict?

### Other

- .
- .
</blockquote>

## `crate-paths`

<blockquote>

## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-v0.1.0) - 2025-06-15

### Fixed

- fix publishing order conflict?

### Other

- .
- use correct `macros` feature
- .
- fmt
- rework clippy + fmt
- .
</blockquote>

## `crate-paths-cli-core`

<blockquote>

## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-cli-core-v0.1.0) - 2025-06-15

### Fixed

- fix publishing order conflict?
- fix #2

### Other

- .
- apply changes made from #3
- Update item.rs
- Update mod.rs
- make clippy happy
- Update lib.rs
- fmt
- rework clippy + fmt
- .
</blockquote>

## `crate-paths-cli`

<blockquote>

## [0.1.0](https://github.com/stayhydated/crate-paths/releases/tag/crate-paths-cli-v0.1.0) - 2025-06-15

### Fixed

- fix publishing order conflict?

### Other

- .
- remove folder option from transitive
- .
- also export cli as a lib. ???
- fmt
- rework clippy + fmt
- .
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).