### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crate-paths-macros",
  "derive_more 2.0.1",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "crate-paths-cli-core",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "Inflector",
  "check_keyword",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "check_keyword",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ license = "MIT OR Apache-2.0"
 publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/crate-paths"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
 check_keyword = "0.4.1"
 clap = "4.5.39"
-crate-paths = { path = "crates/crate-paths", version = "0.1.0" }
-crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.0" }
-crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.0" }
+crate-paths = { path = "crates/crate-paths", version = "0.1.1" }
+crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.1" }
+crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.1" }
 derive_more = "2.0.1"
 getset = "0.1.5"
 prettyplease = "0.2.33"

--- a/crates/crate-paths-cli-core/CHANGELOG.md
+++ b/crates/crate-paths-cli-core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/crate-paths-cli/CHANGELOG.md
+++ b/crates/crate-paths-cli/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-v0.1.0...crate-paths-cli-v0.1.1) - 2025-06-27
+
+### Other
+
+- Update README.md

--- a/crates/crate-paths-macros/CHANGELOG.md
+++ b/crates/crate-paths-macros/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/crate-paths/CHANGELOG.md
+++ b/crates/crate-paths/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION



## 🤖 New release

* `crate-paths-macros`: 0.1.0 -> 0.1.1
* `crate-paths`: 0.1.0 -> 0.1.1
* `crate-paths-cli-core`: 0.1.0 -> 0.1.1
* `crate-paths-cli`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>




## `crate-paths-cli`

<blockquote>

## [0.1.1](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-v0.1.0...crate-paths-cli-v0.1.1) - 2025-06-27

### Other

- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).