### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crate-paths-macros",
  "derive_more 2.0.1",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "crate-paths-cli-core",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "Inflector",
  "check_keyword",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-macros"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "check_keyword",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ license = "MIT OR Apache-2.0"
 publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/crate-paths"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.91"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
 check_keyword = "0.4.1"
 clap = "4.5.39"
-crate-paths = { path = "crates/crate-paths", version = "0.1.2" }
-crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.2" }
-crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.2" }
+crate-paths = { path = "crates/crate-paths", version = "0.1.3" }
+crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.3" }
+crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.3" }
 derive_more = "2.0.1"
 getset = "0.1.5"
 prettyplease = "0.2.33"

--- a/crates/crate-paths-cli-core/CHANGELOG.md
+++ b/crates/crate-paths-cli-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-core-v0.1.2...crate-paths-cli-core-v0.1.3) - 2025-11-21
+
+### Other
+
+- take advantage of docs redirects
+
 ## [0.1.2](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-core-v0.1.1...crate-paths-cli-core-v0.1.2) - 2025-11-21
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `crate-paths-macros`: 0.1.2 -> 0.1.3
* `crate-paths`: 0.1.2 -> 0.1.3
* `crate-paths-cli-core`: 0.1.2 -> 0.1.3
* `crate-paths-cli`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>



## `crate-paths-cli-core`

<blockquote>

## [0.1.3](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-core-v0.1.2...crate-paths-cli-core-v0.1.3) - 2025-11-21

### Other

- take advantage of docs redirects
</blockquote>

## `crate-paths-cli`

<blockquote>

## [0.1.2](https://github.com/stayhydated/crate-paths/compare/crate-paths-cli-v0.1.1...crate-paths-cli-v0.1.2) - 2025-11-21

### Other

- allow skipping local + get crate version if in repo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).