### PR TITLE
chore: release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crate-paths"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "crate-paths-macros",
  "derive_more 2.0.1",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "crate-paths-cli-core",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-cli-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "check_keyword",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "crate-paths-macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "check_keyword",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/crate-paths"
 rust-version = "1.91"
-version = "0.1.3"
+version = "0.1.4"
 
 [workspace.dependencies]
 check_keyword = "0.4.1"
 clap = "4.5.39"
-crate-paths = { path = "crates/crate-paths", version = "0.1.3" }
-crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.3" }
-crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.3" }
+crate-paths = { path = "crates/crate-paths", version = "0.1.4" }
+crate-paths-cli-core = { path = "crates/crate-paths-cli-core", version = "0.1.4" }
+crate-paths-macros = { path = "crates/crate-paths-macros", version = "0.1.4" }
 derive_more = "2.0.1"
 getset = "0.1.5"
 heck = "0.5.0"


### PR DESCRIPTION



## 🤖 New release

* `crate-paths-macros`: 0.1.3 -> 0.1.4
* `crate-paths`: 0.1.3 -> 0.1.4
* `crate-paths-cli-core`: 0.1.3 -> 0.1.4
* `crate-paths-cli`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).